### PR TITLE
Add logic to handle UUID field type

### DIFF
--- a/src/MigBuilder/Renderer.php
+++ b/src/MigBuilder/Renderer.php
@@ -70,6 +70,15 @@ class Renderer
     public static function model($table, $columns, $constraints, $children){
         $code = "";
         $code .= self::model_001_class_start($table);
+
+        // UUID
+        foreach($columns as $column){
+            if ($column->column_key === 'PRI' && $column->data_type === 'char' && $column->max_length === 32) {
+                $code .= "    protected \$keyType = 'string';\r\n";
+                $code .= "    public \$incrementing = false;\r\n\r\n";
+            }
+        }
+
         //Fillable
         $code .= "    // Fillables (remove the columns you don't need)\r\n";
         $code .= "    protected \$fillable = [";

--- a/src/MigBuilder/Renderer.php
+++ b/src/MigBuilder/Renderer.php
@@ -153,6 +153,10 @@ class Renderer
                 $columnType = "unsignedBigInteger";
             }
         }
+        if ($length === 32 && $column->data_type === 'char') {
+            $length = null;
+            $columnType = 'uuid';
+        }
         $indexCode = "";
         $constraintsCode = "";
 


### PR DESCRIPTION
As MySQL does not have a `UUID` field type, it's translated to `char(32)`. This makes the same for reverse engineering.